### PR TITLE
Adjusted to Mediatr 4.0.1

### DIFF
--- a/src/MediatR.SimpleInjector/ContainerExtension.cs
+++ b/src/MediatR.SimpleInjector/ContainerExtension.cs
@@ -1,9 +1,9 @@
-﻿using SimpleInjector;
-using System.Collections.Generic;
-using System.Reflection;
-
-namespace MediatR.SimpleInjector
+﻿namespace MediatR.SimpleInjector
 {
+    using System.Collections.Generic;
+    using System.Reflection;
+    using global::SimpleInjector;
+
     public static class ContainerExtension
     {
         public static Container BuildMediator(this Container container, params Assembly[] assemblies)
@@ -18,13 +18,9 @@ namespace MediatR.SimpleInjector
 
             container.RegisterSingleton<IMediator, Mediator>();
             container.Register(typeof(IRequestHandler<,>), allAssemblies);
-            container.Register(typeof(IAsyncRequestHandler<,>), allAssemblies);
             container.Register(typeof(IRequestHandler<>), allAssemblies);
-            container.Register(typeof(IAsyncRequestHandler<>), allAssemblies);
-            container.Register(typeof(ICancellableAsyncRequestHandler<>), allAssemblies);
             container.RegisterCollection(typeof(INotificationHandler<>), allAssemblies);
-            container.RegisterCollection(typeof(IAsyncNotificationHandler<>), allAssemblies);
-            container.RegisterCollection(typeof(ICancellableAsyncNotificationHandler<>), allAssemblies);
+
             container.RegisterCollection(typeof(IPipelineBehavior<,>), allAssemblies);
 
             container.RegisterSingleton(new SingleInstanceFactory(container.GetInstance));

--- a/src/MediatR.SimpleInjector/MediatR.SimpleInjector.csproj
+++ b/src/MediatR.SimpleInjector/MediatR.SimpleInjector.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="3.0.1" />
-    <PackageReference Include="SimpleInjector" Version="4.0.8" />
+    <PackageReference Include="MediatR" Version="4.0.1" />
+    <PackageReference Include="SimpleInjector" Version="4.0.12" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adjusted to Mediatr 4.0.1
https://jimmybogard.com/mediatr-4-0-released/

"
The last major release of MediatR brought a simplification in design. Instead of having several different IRequest types and IRequestHandler implementations with several flavors, MediatR would try at runtime to determine how a single IRequest should resolve to different IRequestHandler implementations (synchronous, async, async with a cancellation token). In practice, this proved problematic as not all containers support this sort of 'try-resolve' behavior. MediatR relied on try...catch to resolve, which can work, has unintended side effects.

MediatR 4.0 consolidates these design decisions. We'll still have a single IRequest type, but will now have only a single IRequestHandler interface.
"