### PR TITLE
Upgraded for Mediatr 5.x and SimpleInjector 4.3.x

### DIFF
--- a/src/MediatR.SimpleInjector/ContainerExtension.cs
+++ b/src/MediatR.SimpleInjector/ContainerExtension.cs
@@ -18,11 +18,10 @@
 
             container.RegisterSingleton<IMediator, Mediator>();
             container.Register(typeof(IRequestHandler<,>), allAssemblies);
-            container.Register(typeof(IRequestHandler<>), allAssemblies);
-            container.RegisterCollection(typeof(INotificationHandler<>), allAssemblies);
 
-            container.RegisterSingleton(new SingleInstanceFactory(container.GetInstance));
-            container.RegisterSingleton(new MultiInstanceFactory(container.GetAllInstances));
+            container.Collection.Register(typeof(INotificationHandler<>), allAssemblies);
+
+            container.RegisterInstance(new ServiceFactory(container.GetInstance));
 
             return container;
         }

--- a/src/MediatR.SimpleInjector/MediatR.SimpleInjector.csproj
+++ b/src/MediatR.SimpleInjector/MediatR.SimpleInjector.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="4.0.1" />
-    <PackageReference Include="SimpleInjector" Version="4.0.12" />
+    <PackageReference Include="MediatR" Version="5.0.1" />
+    <PackageReference Include="SimpleInjector" Version="4.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgraded for Mediatr 5.x and SimpleInjector 4.3.x based on changes
https://github.com/jbogard/MediatR/wiki/Migration-Guide-4.x-to-5.0

Also change RegisterSingleton to RegisterInstance due to obsolete RegisterSingleton
@haison8x could you please review?